### PR TITLE
refactored into multi-page app

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ Either way, hopefully the game itself is self-explanatory.
 git clone https://github.com/christopher-w-murphy/learn-arithmetic.git
 cd learn-arithmetic/
 pip install -r requirements.txt
-streamlit run app.py
+streamlit run 🏠_Home.py
 ```

--- a/pages/2_🔢_Click_Around_and_Find_Out.py
+++ b/pages/2_🔢_Click_Around_and_Find_Out.py
@@ -1,6 +1,6 @@
 from time import sleep
 
-from streamlit import set_page_config, markdown, title, selectbox, number_input, header, columns, button, empty
+from streamlit import set_page_config, markdown, title, selectbox, number_input, header, columns, button, empty, write
 
 
 ops = {
@@ -28,16 +28,16 @@ def show_result(operation: str, result_time: int = 2) -> None:
     result.empty()
 
 
-def main(n_rows: int = 10, n_cols: int = 10) -> None:
+def click_around_and_find_out(n_rows: int = 10, n_cols: int = 10) -> None:
     """
     :param n_rows: Number of rows to display
     :param n_cols: Number of columns to display
     """
-    set_page_config(page_title="Learn Arithmetic!", page_icon=":1234:", layout="wide")
+    set_page_config(page_title="Click Around and Find Out", page_icon=":1234:", layout="wide")
 
     markdown("<style> p { text-align: center; } </style>", unsafe_allow_html=True)
-
-    title("Learn Arithmetic :heavy_plus_sign: :heavy_minus_sign: :heavy_multiplication_x:")
+    title("Click Around and Find Out :heavy_plus_sign: :heavy_minus_sign: :heavy_multiplication_x:")
+    write("For a better viewing experience, minimize the sidebar.")
 
     op_col, idx_col, jdx_col = columns(3)
     with op_col:
@@ -58,4 +58,4 @@ def main(n_rows: int = 10, n_cols: int = 10) -> None:
 
 
 if __name__ == '__main__':
-    main()
+    click_around_and_find_out()

--- a/🏠_Home.py
+++ b/🏠_Home.py
@@ -1,0 +1,13 @@
+from streamlit import set_page_config, title, markdown
+
+
+def main() -> None:
+    set_page_config(page_title="Learn Arithmetic!", page_icon=":house:")
+
+    title("Learn Arithmetic!")
+
+    markdown("**:point_left: Select a game from the sidebar** and starting playing!")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR refactors the app from a single page to multiple pages in antipication of there eventually being multiple games to play. The file that was `app.py` is now `pages/2_:1234:_Click_Around_and_Find_Out.py` with a home page file, `:house:_Home.py`, taking the place of `app.py`. (The original game filename has the prefix `2_` with the assumption that the next game to be added will be simplier than it.)

You can read more about Streamlit multipage apps [here](https://docs.streamlit.io/library/get-started/multipage-apps). Note, for multipage apps, the `pages/` directory does **not** contain an `__init__.py` file by design.

As for testing, I am able to run the refactored app locally, as expected.